### PR TITLE
MODMO-7. Add edge-orders to app-acquisitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Application Descriptor Repository for the FOLIO Acquisitions application.
 | `mod-invoice-storage`       |
 | `mod-finance`               |
 | `mod-finance-storage`       |
+| `edge-orders`               |
 
 ## UI Modules
 

--- a/app-acquisitions.template.json
+++ b/app-acquisitions.template.json
@@ -41,6 +41,10 @@
     {
       "name": "mod-finance-storage",
       "version": "latest"
+    },
+    {
+      "name": "edge-orders",
+      "version": "latest"
     }
   ],
   "uiModules": [

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>app-acquisitions</artifactId>
   <groupId>org.folio</groupId>
   <description>Application Descriptor Repository for the FOLIO Acquisitions application</description>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
   </pluginRepositories>
 
   <scm>
-    <url>https://https://github.com/folio-org/app-acquisitions</url>
+    <url>https://github.com/folio-org/app-acquisitions</url>
     <connection>scm:git:git://github.com:folio-org/app-acquisitions.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/app-acquisitions.git</developerConnection>
     <tag>HEAD</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>app-acquisitions</artifactId>
   <groupId>org.folio</groupId>
   <description>Application Descriptor Repository for the FOLIO Acquisitions application</description>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODMO-7
Add edge-orders from app-edge-complete to app-acquistions.
Dependencies in edge-orders module descriptor are already optional, so for each particular library app-gobi, app-ebsconet, app-mosaic can be enabled separately. 
Edge-orders is included in core app-acqusitions with this change and can handle all these 3 optional integrations.