### PR TITLE
RANCHER-2321: Align pom.xml with template pattern for Maven parameter passing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,16 +3,18 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <name>app-acquisitions</name>
+  <name>${project.name}</name>
   <artifactId>app-acquisitions</artifactId>
   <groupId>org.folio</groupId>
   <description>Application Descriptor Repository for the FOLIO Acquisitions application</description>
   <version>1.1.0-SNAPSHOT</version>
 
   <properties>
+    <project.name>app-acquisitions</project.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <folio-application-generator.version>1.1.0</folio-application-generator.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+    <templatePath>${basedir}/${project.name}.template.json</templatePath>
   </properties>
 
   <build>
@@ -29,7 +31,7 @@
           </execution>
         </executions>
         <configuration>
-          <templatePath>${basedir}/app-acquisitions.template.json</templatePath>
+          <templatePath>${templatePath}</templatePath>
           <moduleRegistries>
             <registry>
               <type>okapi</type>
@@ -92,9 +94,9 @@
   </pluginRepositories>
 
   <scm>
-    <url>https://https://github.com/folio-org/app-acquisitions</url>
-    <connection>scm:git:git://github.com:folio-org/app-acquisitions.git</connection>
-    <developerConnection>scm:git:git@github.com:folio-org/app-acquisitions.git</developerConnection>
+    <url>https://github.com/folio-org/${project.name}</url>
+    <connection>scm:git:git://github.com:folio-org/${project.name}.git</connection>
+    <developerConnection>scm:git:git@github.com:folio-org/${project.name}.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 </project>


### PR DESCRIPTION
**Summary:**
This PR aligns the app-acquisitions pom.xml with the new template pattern from pipelines-shared-library to enable Maven command-line parameter overriding and standardize project naming.

**Changes:**
- Add `project.name` property set to 'app-acquisitions'
- Add `templatePath` property using `${basedir}/${project.name}.template.json`
- Update templatePath configuration to use `${templatePath}` property
- Update name element to use `${project.name}` property  
- Update SCM URLs to use `${project.name}` property
- Fix double https:// protocol in SCM URL

**Benefits:**
- Enables Maven command-line parameter overriding for dynamic templatePath
- Standardizes project naming across repositories
- Aligns with pipelines-shared-library template pattern
- Supports automated workflow parameter passing

**Testing:**
This change is part of RANCHER-2321 effort to standardize pom.xml files across all app-* repositories for improved CI/CD workflows.

**Related:** RANCHER-2321