### PR TITLE
RANCHER-2969. Update `release-application-version.yml` to allow customizable base branch input for releases

### DIFF
--- a/.github/workflows/release-application-version.yml
+++ b/.github/workflows/release-application-version.yml
@@ -11,6 +11,11 @@ on:
         required: false
         type: string
         default: ''
+      base_branch:
+        description: 'Release branch the commit belongs to (defaults to dispatch branch)'
+        required: false
+        type: string
+        default: ''
       release_notes:
         description: 'Release notes body text'
         required: false
@@ -30,7 +35,7 @@ jobs:
       repo_owner: ${{ github.repository_owner }}
       repo_name: ${{ github.event.repository.name }}
       commit_sha: ${{ inputs.commit_sha }}
-      base_branch: ${{ github.ref_name }}
+      base_branch: ${{ inputs.base_branch != '' && inputs.base_branch || github.ref_name }}
       release_notes: ${{ inputs.release_notes }}
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Adds an optional `base_branch` `workflow_dispatch` input to `Release Application Version` so the operator can specify the release branch the released commit belongs to. When left blank, the workflow falls back to `github.ref_name` — preserving existing behavior.

### Motivation

The reusable release flow renders a Slack notification whose `Branch` field is wired to the `base_branch` input. The caller previously hardcoded `base_branch: ${{ github.ref_name }}`, which is the branch the operator picked in the *Run workflow* dropdown — not necessarily the branch the released commit lives on.

The mismatch shows up when the operator dispatches from `master` while passing a `commit_sha` from a release branch (e.g. `R1-2026`): the GitHub release is created against the right SHA, but the Slack message says `Branch: master`, which is misleading.

The post-merge flow does not have this problem because it queries the merged PR's `baseRefName` via `kitfox-github/.github/actions/get-pr-info`. The manual dispatch has no PR context — the simplest fix is to let the operator pass the branch explicitly.

### Changes

- New optional input `base_branch` on `release-application-version.yml` (description: "Release branch the commit belongs to (defaults to dispatch branch)").
- Job `with:` now uses `${{ inputs.base_branch != '' && inputs.base_branch || github.ref_name }}` so the override flows through when set, and dispatching without it behaves exactly as before.
- No changes to the reusable flow (`kitfox-github/.github/workflows/release-application-version-flow.yml`) — it already accepts `base_branch`.
- `workflow_dispatch` input defaults cannot reference `${{ github.* }}` contexts, so the fallback is expressed in the job's `with:` block, not as the input default.

### Verification

- Dispatch from `master` with `commit_sha` on `R1-2026` and `base_branch=R1-2026` — Slack `Branch` field shows `R1-2026` (linked to `tree/R1-2026`); GitHub release created against the supplied SHA.
- Dispatch with `base_branch` blank — Slack shows `github.ref_name`, identical to today's behavior.
- `dry_run=true` continues to short-circuit before release creation and notifications.

### Follow-up

This is the pilot rollout on `app-acquisitions`. The same one-file patch has to be propagated to `folio-app-template` (canonical) and every other `app-*` repo before the change is fully usable across the fleet — tracked by RANCHER-2969.

Refs: RANCHER-2969