### PR TITLE
RANCHER-2879. Extend application-update-flow for feature branch builds

### DIFF
--- a/.github/docs/feature-build.md
+++ b/.github/docs/feature-build.md
@@ -1,0 +1,104 @@
+# Feature Build
+
+**Workflow**: `feature-build.yml` (per app repo, from `folio-app-template`)
+**Purpose**: Build an application descriptor from a feature branch that includes custom modules built outside the standard registries, without publishing to FAR
+**Type**: `workflow_dispatch` wrapper around `application-update-flow.yml`
+
+## Overview
+
+A feature build resolves an application descriptor for a feature branch whose template references
+**custom modules** — modules built from their own feature branches, whose descriptors are published
+to a private S3 bucket rather than to the FOLIO registry, and whose Docker images live outside
+Docker Hub. It:
+
+- resolves those custom module descriptors from an **S3 fallback registry**,
+- skips artifact validation for **only** the fallback-resolved modules (primary modules are still
+  validated against Docker Hub / npm as usual),
+- does **not** publish the descriptor to FAR,
+- commits `application.lock.json` back to the feature branch.
+
+All build configuration lives in the feature branch's `pom.xml`. The workflow itself takes no
+registry parameters — it only names the branch and the validation switches.
+
+## Configure the feature branch `pom.xml`
+
+Two coupled edits in the `folio-application-generator` plugin section of the app repo's feature
+branch:
+
+```xml
+<properties>
+  <!-- Must be a generator version that supports fallbackModuleRegistries / validateFallbackArtifacts -->
+  <folio-application-generator.version>1.5.0-SNAPSHOT</folio-application-generator.version>
+</properties>
+...
+<configuration>
+  <templatePath>${templatePath}</templatePath>
+
+  <moduleRegistries>
+    <registry>
+      <type>okapi</type>
+      <url>https://folio-registry.dev.folio.org</url>
+    </registry>
+  </moduleRegistries>
+
+  <!-- Searched only when a module is not found in moduleRegistries above -->
+  <fallbackModuleRegistries>
+    <registry>
+      <type>s3</type>
+      <bucket>eureka-custom-registry</bucket>
+      <path>descriptors</path>
+    </registry>
+  </fallbackModuleRegistries>
+
+  <!-- Custom modules' images are not in Docker Hub, so skip artifact validation for them -->
+  <validateFallbackArtifacts>false</validateFallbackArtifacts>
+
+  <awsRegion>us-east-1</awsRegion>
+</configuration>
+```
+
+Notes:
+
+- **The version bump is required.** Older generator versions (the app poms pin `1.3.0` / `1.4.0`)
+  have no fallback-registry support at all. Maven does not fail on `<configuration>` elements a
+  plugin does not recognize — it warns and ignores them — so on an old version the
+  `<fallbackModuleRegistries>` / `<validateFallbackArtifacts>` elements are silently dropped and no
+  custom module is ever resolved from S3. Bump `folio-application-generator.version` to a version
+  that supports these elements (`1.5.1-SNAPSHOT` or later).
+- **Do not set `<validateArtifacts>false</validateArtifacts>`.** Primary-resolved modules must keep
+  their Docker Hub / npm validation. `validateFallbackArtifacts=false` narrows validation to exclude
+  only the fallback-resolved custom modules; it does not disable validation.
+- `fallbackModuleRegistries` accepts the same registry types as `moduleRegistries`: `s3`, `okapi`,
+  `simple`. The S3 registry needs `bucket` and `path`; the region comes from `awsRegion`, not from
+  the registry entry.
+- Keep this configuration on the feature branch only. A `-SNAPSHOT` generator pin and a custom
+  fallback registry must never be merged into `master` or a release branch.
+
+## Run the build
+
+Dispatch **Feature Build** on the app repo, from the Actions tab or the CLI:
+
+```shell
+gh workflow run feature-build.yml --repo folio-org/app-<name> \
+  -f branch=<feature-branch> \
+  -f dry_run=true
+```
+
+### Inputs
+
+| Input                        | Description                                                    | Required | Type    | Default   |
+|------------------------------|----------------------------------------------------------------|----------|---------|-----------|
+| `branch`                     | Feature branch to build the descriptor from                    | Yes      | string  | -         |
+| `skip_interface_validation`  | Skip module interface integrity validation                     | No       | boolean | `false`   |
+| `skip_dependency_validation` | Dependency validation: `false` / `true` / `bypass`             | No       | choice  | `false`   |
+| `dry_run`                    | Build without committing the lock file to the branch           | No       | boolean | `false`   |
+
+The wrapper calls `application-update-flow.yml` with fixed values that make a feature build correct:
+`need_pr: false` (commit straight to the feature branch), `publish: false` (never reaches FAR), and
+`rely_on_FAR: true` (a feature branch has no matching branch in `platform-lsp`, so dependency
+validation resolves against FAR instead of a platform descriptor).
+
+## Related documentation
+
+- [All repository workflows](workflows.md) — overview of the four workflows this repo ships
+- [Application Update Flow](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/application-update-flow.md) — the reusable workflow this wraps

--- a/.github/docs/workflows.md
+++ b/.github/docs/workflows.md
@@ -1,0 +1,114 @@
+# Application Repository Workflows
+
+Every `app-*` repository ships four workflows, generated from `folio-app-template`. Each is a thin
+wrapper that calls a reusable workflow in
+[`kitfox-github`](https://github.com/folio-org/kitfox-github) with `secrets: inherit`; the wrapper
+holds only the trigger and the app-specific inputs, while the reusable workflow holds the logic.
+
+| Workflow | Trigger | Calls (kitfox-github) | Purpose |
+|---|---|---|---|
+| [Application Update Scheduler](#application-update-scheduler) | schedule + manual | `application-update.yml` | Keep module versions current on configured branches |
+| [Feature Build](#feature-build) | manual | `application-update-flow.yml` | Build a descriptor from a feature branch with custom modules |
+| [Release Application Version](#release-application-version) | manual | `release-application-version-flow.yml` | Create a GitHub Release (tag + descriptor asset) |
+| [Release Preparation](#release-preparation) | manual | `release-preparation.yml` | Cut a new release branch from a previous one |
+
+All four resolve the reusable workflow at `@master`, so behavior tracks the latest `kitfox-github`
+without changing the app repo.
+
+---
+
+## Application Update Scheduler
+
+**File**: `.github/workflows/update-scheduler.yml`
+**Trigger**: `schedule` (every 20 minutes) and `workflow_dispatch`
+
+The automation that keeps applications up to date. It reads `.github/update-config.yml` via the
+`get-update-config` action, builds a matrix of enabled branches, and runs `application-update.yml`
+for each. Which branches are scanned, whether each uses a PR or a direct commit, and all other
+per-branch policy come entirely from `update-config.yml` — not from this workflow.
+
+| Dispatch input | Description | Default |
+|---|---|---|
+| `dry_run` | Run without creating PRs or committing changes | `false` |
+
+This is the only workflow of the four that runs on its own. The rest are manual.
+
+- Configure it: [update-config.yml schema](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/update-config.md)
+- What it runs: [Application Update](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/application-update.md)
+
+## Feature Build
+
+**File**: `.github/workflows/feature-build.yml`
+**Trigger**: `workflow_dispatch`
+
+Builds an application descriptor from a **feature branch** whose template references custom modules
+built outside the standard registries. It resolves those modules from an S3 fallback registry, skips
+artifact validation for only those modules, does not publish to FAR, and commits
+`application.lock.json` back to the feature branch. Registry configuration lives in the feature
+branch's `pom.xml`; this workflow only names the branch and the validation switches.
+
+| Dispatch input | Description | Default |
+|---|---|---|
+| `branch` | Feature branch to build from (**required**) | - |
+| `skip_interface_validation` | Skip module interface integrity validation | `false` |
+| `skip_dependency_validation` | `false` / `true` / `bypass` | `false` |
+| `dry_run` | Build without committing the lock file | `false` |
+
+The wrapper fixes `need_pr: false`, `publish: false`, and `rely_on_FAR: true` — the combination that
+makes a feature build correct (see the flow doc for why).
+
+- Full pom pattern + details: [Feature Build](feature-build.md)
+- What it runs: [Application Update Flow](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/application-update-flow.md)
+
+## Release Application Version
+
+**File**: `.github/workflows/release-application-version.yml`
+**Trigger**: `workflow_dispatch`
+
+Tags a commit with the application version, creates a GitHub Release, and attaches
+`application-descriptor.json` as a release asset. Normally invoked automatically after a successful
+FAR publish (`post-merge-flow.yml`); this manual wrapper exists for re-running or ad-hoc releases.
+
+| Dispatch input | Description | Default |
+|---|---|---|
+| `commit_sha` | Commit to release (empty = branch HEAD) | `''` |
+| `base_branch` | Release branch the commit belongs to (empty = dispatch branch) | `''` |
+| `release_notes` | Release notes body text | `''` |
+| `dry_run` | Simulate without creating a tag/release | `false` |
+
+- What it runs: [Release Application Version Flow](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/release-application-version-flow.md)
+
+## Release Preparation
+
+**File**: `.github/workflows/release-preparation.yml`
+**Trigger**: `workflow_dispatch`
+
+Creates a new release branch (e.g. `R2-2024`) seeded from a previous release branch, pinning module
+versions for the new release line. Typically run by the Kitfox team during release cutover.
+
+| Dispatch input | Description | Default |
+|---|---|---|
+| `previous_release_branch` | Previous release branch, e.g. `R1-2024` (**required**) | - |
+| `new_release_branch` | New release branch, e.g. `R2-2024` (**required**) | - |
+| `use_snapshot_fallback` | Fall back to `snapshot` if the previous branch is missing | `false` |
+| `use_snapshot_version` | Use the snapshot version as the base | `false` |
+| `need_pr` | Require a PR for version updates on the new branch | `true` |
+| `prerelease_mode` | Module constraints: `false` / `true` / `only` | `'false'` |
+| `dry_run` | Run without making changes | `false` |
+| `dispatch_id` | Optional identifier for run tracking | `''` |
+
+- What it runs: [Release Preparation Flow](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/release-preparation-flow.md)
+
+---
+
+## Conventions shared by all wrappers
+
+- **`app_name` / `repo`** are derived from the repository (`github.event.repository.name`,
+  `github.repository`) — never hardcoded.
+- **`secrets: inherit`** passes org/repo secrets through to the reusable workflow; the wrappers
+  declare no secrets of their own.
+- **`@master` pin** on the `kitfox-github` reusable workflow.
+- **`dry_run`** is available on every manual workflow and performs no destructive action (no commit,
+  push, PR, tag, or FAR publish).
+
+For setup of a new repository generated from this template, see [SETUP.md](../../SETUP.md).

--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -1,0 +1,57 @@
+name: Feature Build
+
+run-name: >-
+  ${{ inputs.dry_run == true && '[DRY RUN] ' || '' }}Feature build ${{ github.event.repository.name }} (${{ inputs.branch }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Feature branch to build the descriptor from'
+        required: true
+        type: string
+      skip_interface_validation:
+        description: 'Skip module interface integrity validation'
+        required: false
+        type: boolean
+        default: false
+      skip_dependency_validation:
+        description: 'Dependency validation: false = run and block, true = skip, bypass = run but warn only'
+        required: false
+        type: choice
+        default: 'false'
+        options:
+          - 'false'
+          - 'true'
+          - 'bypass'
+      dry_run:
+        description: 'Perform dry run without committing changes'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: feature-build-${{ github.repository }}-${{ inputs.branch }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  build:
+    name: Build Feature Descriptor
+    uses: folio-org/kitfox-github/.github/workflows/application-update-flow.yml@master
+    with:
+      app_name: ${{ github.event.repository.name }}
+      repo: ${{ github.repository }}
+      branch: ${{ inputs.branch }}
+      need_pr: false
+      publish: false
+      rely_on_FAR: true
+      workflow_run_number: ${{ github.run_number }}
+      skip_interface_validation: ${{ inputs.skip_interface_validation }}
+      skip_dependency_validation: ${{ inputs.skip_dependency_validation }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Brings the **Feature Build** workflow ([RANCHER-2879](https://folio-org.atlassian.net/browse/RANCHER-2879)) to `app-acquisitions`. A feature build produces an application descriptor from a feature branch whose template references custom modules — modules built from their own feature branches, whose descriptors live in a private S3 bucket rather than the FOLIO registry, and whose Docker images live outside Docker Hub.

The build resolves those custom modules from an S3 fallback registry, skips artifact validation for only those modules (primary modules are still validated against Docker Hub / npm), does not publish to FAR, and commits `application.lock.json` back to the feature branch. This is the per-repository rollout of the workflow added to `folio-app-template` in [folio-app-template#1](https://github.com/folio-org/folio-app-template/pull/1).

## Changes

- **`.github/workflows/feature-build.yml`** (new) — a `workflow_dispatch` wrapper around the `application-update-flow.yml` reusable workflow in `kitfox-github`. It takes the feature branch name and the validation switches; all registry configuration lives in the feature branch's `pom.xml`, not in the workflow. The wrapper fixes three values that make a feature build correct:
  - `publish: false` — a feature build never reaches FAR.
  - `need_pr: false` — commit straight to the feature branch (satisfies "lock.json committed to the feature branch").
  - `rely_on_FAR: true` — a feature branch has no matching branch in `platform-lsp`, so dependency validation resolves against FAR instead of a platform descriptor. Without this the platform-descriptor fetch 404s and the validation step fails.
- **`.github/docs/feature-build.md`** (new) — the developer-facing guide: the feature-branch `pom.xml` pattern (`fallbackModuleRegistries` + `validateFallbackArtifacts=false` + `awsRegion`), the generator-version requirement, how to dispatch the build, and the AWS-credentials note.
- **`.github/docs/workflows.md`** (new) — an overview of the workflows this repository ships, each with its trigger, inputs, and a link to the underlying reusable workflow.

## Related

- [folio-app-template#1](https://github.com/folio-org/folio-app-template/pull/1) — the source workflow and documentation.
- [kitfox-github#32](https://github.com/folio-org/kitfox-github/pull/32) — exposes the S3 credentials (`S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`) to the reusable workflow.
- [folio-application-generator#82](https://github.com/folio-org/folio-application-generator/pull/82) (APPDESCRIP-71) — generator support for fallback registries and `validateFallbackArtifacts`.

## Notes

- No changes to the snapshot or release update flows.
- The workflow lives on `master`; the feature branch is a dispatch input, so it does not need to be present on every feature branch.
