### PR TITLE
RANCHER-2879. Extend application-update-flow for feature branch builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <project.name>app-acquisitions</project.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <folio-application-generator.version>1.4.0-SNAPSHOT</folio-application-generator.version>
+    <folio-application-generator.version>1.5.0-SNAPSHOT</folio-application-generator.version>
     <templatePath>${basedir}/application.template.json</templatePath>
   </properties>
 
@@ -31,12 +31,22 @@
         </executions>
         <configuration>
           <templatePath>${templatePath}</templatePath>
+          <validateArtifacts>true</validateArtifacts>
+          <validateFallbackArtifacts>false</validateFallbackArtifacts>
+          <awsRegion>us-west-2</awsRegion>
           <moduleRegistries>
             <registry>
               <type>okapi</type>
               <url>https://folio-registry.dev.folio.org</url>
             </registry>
           </moduleRegistries>
+          <fallbackModuleRegistries>
+            <registry>
+              <type>s3</type>
+              <bucket>eureka-application-registry</bucket>
+              <path>descriptors</path>
+            </registry>
+          </fallbackModuleRegistries>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Summary

Adds the `folio-application-generator` configuration to `app-acquisitions` ([RANCHER-2879](https://folio-org.atlassian.net/browse/RANCHER-2879)) needed to resolve custom feature-branch modules from the S3 fallback registry during a feature build. This brings the app's `snapshot` pom in line with the `folio-app-template` baseline.

## Changes (`pom.xml`)

- **`fallbackModuleRegistries`** → S3 registry `eureka-application-registry`, prefix `descriptors`. Searched only when a module is not found in the primary `okapi` registry, so descriptors for custom modules built from feature branches resolve from S3.
- **`validateFallbackArtifacts=false`** — skip Docker/npm artifact validation for **only** the fallback-resolved custom modules (their images live outside Docker Hub).
- **`validateArtifacts=true`** — primary (okapi-resolved) modules are still artifact-validated as before.
- **`awsRegion=us-west-2`** — the region of the `eureka-application-registry` bucket.
- **generator version `1.4.0-SNAPSHOT` → `1.5.0-SNAPSHOT`** — older versions have no fallback-registry support and would silently ignore the config above.

## Notes

- Non-S3 builds are unaffected: the S3 client is only constructed when a module actually falls through to the `s3` fallback, so regular snapshot resolution is unchanged.
- Reaching the S3 bucket at CI time relies on the AWS credentials wired in the reusable flow (org secrets `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`).
- At CI time the executed generator version comes from the `generate-application-descriptor` action (`use_input_generator_version: true`), so the pom version here governs local `mvn` builds and keeps the template/pom consistent.

## Related

- [app-acquisitions#165](https://github.com/folio-org/app-acquisitions/pull/165) — the `feature-build.yml` workflow and docs.
- [kitfox-github#32](https://github.com/folio-org/kitfox-github/pull/32) — exposes the S3 credentials to the reusable flow.
- [folio-app-template#1](https://github.com/folio-org/folio-app-template/pull/1) — the template baseline this config mirrors.
