### PR TITLE
RANCHER-3066. Feature build corrections: application-update.yml orchestration + commit-hash app version

### DIFF
--- a/.github/docs/feature-build.md
+++ b/.github/docs/feature-build.md
@@ -2,7 +2,7 @@
 
 **Workflow**: `feature-build.yml` (per app repo, from `folio-app-template`)
 **Purpose**: Build an application descriptor from a feature branch that includes custom modules built outside the standard registries, without publishing to FAR
-**Type**: `workflow_dispatch` wrapper around `application-update-flow.yml`
+**Type**: `workflow_dispatch` wrapper around `application-update.yml`
 
 ## Overview
 
@@ -15,7 +15,9 @@ Docker Hub. It:
 - skips artifact validation for **only** the fallback-resolved modules (primary modules are still
   validated against Docker Hub / npm as usual),
 - does **not** publish the descriptor to FAR,
-- commits `application.lock.json` back to the feature branch.
+- commits `application.lock.json` back to the feature branch,
+- versions the app with the feature branch's **commit hash** (`X.Y.Z-SNAPSHOT.<shortSha>`) instead
+  of a build number, so a feature app is distinguishable from a snapshot app in FAR.
 
 All build configuration lives in the feature branch's `pom.xml`. The workflow itself takes no
 registry parameters — it only names the branch and the validation switches.
@@ -89,16 +91,24 @@ gh workflow run feature-build.yml --repo folio-org/app-<name> \
 | Input                        | Description                                                    | Required | Type    | Default   |
 |------------------------------|----------------------------------------------------------------|----------|---------|-----------|
 | `branch`                     | Feature branch to build the descriptor from                    | Yes      | string  | -         |
+| `commit_hash`                | Commit hash used as the descriptor build suffix (empty = auto-detect from the branch HEAD) | No | string | `''` |
 | `skip_interface_validation`  | Skip module interface integrity validation                     | No       | boolean | `false`   |
 | `skip_dependency_validation` | Dependency validation: `false` / `true` / `bypass`             | No       | choice  | `false`   |
 | `dry_run`                    | Build without committing the lock file to the branch           | No       | boolean | `false`   |
 
-The wrapper calls `application-update-flow.yml` with fixed values that make a feature build correct:
+A `resolve-build-number` job runs first: it uses `commit_hash` when supplied, otherwise reads the
+branch HEAD short SHA (`gh api repos/<repo>/commits/<branch> --jq '.sha[0:7]'`). The resolved value
+is passed as `build_number` and becomes the version suffix (`X.Y.Z-SNAPSHOT.<shortSha>`).
+
+The wrapper calls `application-update.yml` with fixed values that make a feature build correct:
 `need_pr: false` (commit straight to the feature branch), `publish: false` (never reaches FAR), and
 `rely_on_FAR: true` (a feature branch has no matching branch in `platform-lsp`, so dependency
-validation resolves against FAR instead of a platform descriptor).
+validation resolves against FAR instead of a platform descriptor). Routing through the orchestrator
+(`application-update.yml`) rather than the flow directly also produces the run summary and the Slack
+notification.
 
 ## Related documentation
 
 - [All repository workflows](workflows.md) — overview of the four workflows this repo ships
-- [Application Update Flow](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/application-update-flow.md) — the reusable workflow this wraps
+- [Application Update](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/application-update.md) — the orchestrator this wraps (adds the summary + notification)
+- [Application Update Flow](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/application-update-flow.md) — the underlying flow the orchestrator runs

--- a/.github/docs/workflows.md
+++ b/.github/docs/workflows.md
@@ -8,7 +8,7 @@ holds only the trigger and the app-specific inputs, while the reusable workflow 
 | Workflow | Trigger | Calls (kitfox-github) | Purpose |
 |---|---|---|---|
 | [Application Update Scheduler](#application-update-scheduler) | schedule + manual | `application-update.yml` | Keep module versions current on configured branches |
-| [Feature Build](#feature-build) | manual | `application-update-flow.yml` | Build a descriptor from a feature branch with custom modules |
+| [Feature Build](#feature-build) | manual | `application-update.yml` | Build a descriptor from a feature branch with custom modules |
 | [Release Application Version](#release-application-version) | manual | `release-application-version-flow.yml` | Create a GitHub Release (tag + descriptor asset) |
 | [Release Preparation](#release-preparation) | manual | `release-preparation.yml` | Cut a new release branch from a previous one |
 
@@ -50,15 +50,18 @@ branch's `pom.xml`; this workflow only names the branch and the validation switc
 | Dispatch input | Description | Default |
 |---|---|---|
 | `branch` | Feature branch to build from (**required**) | - |
+| `commit_hash` | Commit hash used as the version suffix (empty = auto-detect from branch HEAD) | `''` |
 | `skip_interface_validation` | Skip module interface integrity validation | `false` |
 | `skip_dependency_validation` | `false` / `true` / `bypass` | `false` |
 | `dry_run` | Build without committing the lock file | `false` |
 
 The wrapper fixes `need_pr: false`, `publish: false`, and `rely_on_FAR: true` — the combination that
-makes a feature build correct (see the flow doc for why).
+makes a feature build correct (see the flow doc for why) — and versions the app with the feature
+branch's commit hash (`X.Y.Z-SNAPSHOT.<shortSha>`). It routes through the orchestrator
+`application-update.yml`, so the run also gets a summary and a Slack notification.
 
 - Full pom pattern + details: [Feature Build](feature-build.md)
-- What it runs: [Application Update Flow](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/application-update-flow.md)
+- What it runs: [Application Update](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/application-update.md)
 
 ## Release Application Version
 

--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -10,6 +10,11 @@ on:
         description: 'Feature branch to build the descriptor from'
         required: true
         type: string
+      commit_hash:
+        description: 'Commit hash to use as the descriptor build suffix (leave empty to auto-detect from the branch HEAD)'
+        required: false
+        type: string
+        default: ''
       skip_interface_validation:
         description: 'Skip module interface integrity validation'
         required: false
@@ -40,9 +45,33 @@ permissions:
   issues: write
 
 jobs:
+  resolve-build-number:
+    name: Resolve Build Number
+    runs-on: ubuntu-latest
+    outputs:
+      build_number: ${{ steps.resolve.outputs.build_number }}
+    steps:
+      - name: Resolve build number
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          COMMIT_HASH: ${{ inputs.commit_hash }}
+        run: |
+          set -eo pipefail
+          if [[ -n "$COMMIT_HASH" ]]; then
+            build_number="$COMMIT_HASH"
+          else
+            build_number=$(gh api "repos/$REPO/commits/$BRANCH" --jq '.sha[0:7]')
+          fi
+          echo "::notice::Feature build number (suffix): $build_number"
+          echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build Feature Descriptor
-    uses: folio-org/kitfox-github/.github/workflows/application-update-flow.yml@master
+    needs: resolve-build-number
+    uses: folio-org/kitfox-github/.github/workflows/application-update.yml@master
     with:
       app_name: ${{ github.event.repository.name }}
       repo: ${{ github.repository }}
@@ -50,6 +79,7 @@ jobs:
       need_pr: false
       publish: false
       rely_on_FAR: true
+      build_number: ${{ needs.resolve-build-number.outputs.build_number }}
       workflow_run_number: ${{ github.run_number }}
       skip_interface_validation: ${{ inputs.skip_interface_validation }}
       skip_dependency_validation: ${{ inputs.skip_dependency_validation }}


### PR DESCRIPTION
## Summary

Part of [RANCHER-3066](https://folio-org.atlassian.net/browse/RANCHER-3066). Rolls the corrected `feature-build.yml` from `folio-app-template` into `app-acquisitions`. This mirrors folio-org/folio-app-template#2 exactly.

Two corrections:

1. **Summary + notification.** Route feature builds through the orchestrator `application-update.yml` instead of `application-update-flow.yml` directly, so a run now produces a summary and a Slack notification.
2. **Commit-hash version.** Version feature apps with the feature-branch commit hash (`X.Y.Z-SNAPSHOT.<shortSha>`) instead of the CI run number, so a feature app is distinguishable from a snapshot app in FAR.

## Changes

**`feature-build.yml`**
- `uses:` repointed to `application-update.yml@master`.
- New optional `commit_hash` dispatch input (empty = auto-detect from the branch HEAD).
- New `resolve-build-number` job that resolves the branch HEAD short SHA (or uses `commit_hash`) and passes it as `build_number`.

**Docs**: `feature-build.md`, `workflows.md`.

## Depends on

Requires folio-org/kitfox-github#34 (the `build_number` input on `application-update.yml@master`). **Merge that PR first.**

## Related PRs

- folio-org/folio-app-template#2 — source-of-truth template change.
- folio-org/kitfox-github#34 — the reusable-workflow mechanism.
